### PR TITLE
created "base" stage/layer in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Base Stage/Layer
-FROM node:10.16-alpine as base
+FROM node:10.16-alpine as node-layer
 WORKDIR /usr/src/app
 
 # Client App
-FROM base as client-app
+FROM node-layer as client-app
 LABEL authors="John Papa"
 COPY ["package.json", "npm-shrinkwrap.json*", "./"]
 # COPY package*.json ./
@@ -14,14 +14,14 @@ ENV VUE_APP_API $VUE_APP_API
 RUN npm run build
 
 # Node server
-FROM base as node-server
+FROM node-layer as node-server
 COPY ["package.json", "npm-shrinkwrap.json*", "./"]
 # COPY package*.json ./
 RUN npm install --production --silent && mv node_modules ../
 COPY server.js .
 
 # Final image
-FROM base
+FROM node-layer
 WORKDIR /usr/src/app
 # get the node_modules
 COPY --from=node-server /usr/src /usr/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base Stage/Layer
-FROM node:10.13-alpine as base
+FROM node:10.16-alpine as base
 WORKDIR /usr/src/app
 
 # Client App

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-# Client App
-FROM node:10.13-alpine as client-app
-LABEL authors="John Papa"
+# Base Stage/Layer
+FROM node:10.13-alpine as base
 WORKDIR /usr/src/app
+
+# Client App
+FROM base as client-app
+LABEL authors="John Papa"
 COPY ["package.json", "npm-shrinkwrap.json*", "./"]
 RUN npm install --silent
 COPY . .
@@ -10,15 +13,13 @@ ENV VUE_APP_API $VUE_APP_API
 RUN npm run build
 
 # Node server
-FROM node:10.13-alpine as node-server
-WORKDIR /usr/src/app
+FROM base as node-server
 COPY ["package.json", "npm-shrinkwrap.json*", "./"]
 RUN npm install --production --silent && mv node_modules ../
 COPY server.js .
 
 # Final image
-FROM node:10.13-alpine
-WORKDIR /usr/src/app
+FROM base
 # get the node_modules
 COPY --from=node-server /usr/src /usr/src
 # get the client app


### PR DESCRIPTION
This takes advantage of layer caching which reduces disk usage (not resulting image size) and the time it takes to build.

FWIW, also as a practice of not running the image with the root (default) user, I set my USER to node `USER node:node` 
in the stage that has the CMD or ENTRYPOINT that ultimately runs the process in the image _after_ all COPY commands. 

This necessitates using chown when copying from other stages 
`COPY --from=node-server --chown=node:node /usr/src /usr/src` 
(prior to setting `USER node:node` of course).